### PR TITLE
Add visibility selector for data.openstack_images_image_v2

### DIFF
--- a/FWaaS/instaces.tf
+++ b/FWaaS/instaces.tf
@@ -1,6 +1,7 @@
 data "openstack_images_image_v2" "image" {
   most_recent = true
 
+  visibility = "public"
   properties = {
     os_distro  = "ubuntu"
     os_version = "16.04"

--- a/example-setup/main.tf
+++ b/example-setup/main.tf
@@ -72,6 +72,7 @@ data "openstack_networking_network_v2" "public_network" {
 data "openstack_images_image_v2" "image" {
   most_recent = true
 
+  visibility = "public"
   properties = {
     os_distro  = "ubuntu"
     os_version = "16.04"

--- a/lbaas/main.tf
+++ b/lbaas/main.tf
@@ -1,6 +1,7 @@
 data "openstack_images_image_v2" "image" {
   most_recent = true
 
+  visibility = "public"
   properties = {
     os_distro  = "ubuntu"
     os_version = "16.04"

--- a/simple-instance/image.tf
+++ b/simple-instance/image.tf
@@ -1,6 +1,7 @@
 data "openstack_images_image_v2" "image" {
   most_recent = true
 
+  visibility = "public"
   properties = {
     os_distro  = "ubuntu"
     os_version = "16.04"


### PR DESCRIPTION
The current image select parameters might select a snapshot, which is
normally not what you expect from this code. This change adds a
visibility selector for "public" images. Because those can only be
created by OpenStack admins, it more accurately determines the cloud
image.