### PR TITLE
VPN example: Use endpoint groups for greater flexibility

### DIFF
--- a/vpnaas/modules/network/network.tf
+++ b/vpnaas/modules/network/network.tf
@@ -42,8 +42,16 @@ resource "openstack_vpnaas_service_v2" "network" {
   depends_on     = ["openstack_networking_router_interface_v2.network"]
   name           = "${var.name}"
   router_id      = "${openstack_networking_router_v2.network.id}"
-  subnet_id      = "${openstack_networking_subnet_v2.network.id}"
   admin_state_up = "true"
+}
+
+resource "openstack_vpnaas_endpoint_group_v2" "local" {
+  name      = "${var.name} local"
+  type      = "subnet"
+  endpoints = ["${openstack_networking_subnet_v2.network.id}"]
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 output "vpnservice_id" {
@@ -64,4 +72,8 @@ output "peer_id" {
 
 output "cidr" {
   value = "${var.cidr}"
+}
+
+output "local_endpoint_group_id" {
+  value = "${openstack_vpnaas_endpoint_group_v2.local.id}"
 }

--- a/vpnaas/modules/network/network.tf
+++ b/vpnaas/modules/network/network.tf
@@ -1,5 +1,5 @@
 provider "openstack" {
-  region = "${var.region}"
+  region = var.region
 }
 
 data "openstack_networking_network_v2" "ext_net" {
@@ -7,73 +7,73 @@ data "openstack_networking_network_v2" "ext_net" {
 }
 
 resource "openstack_networking_network_v2" "network" {
-  name           = "${var.name}"
+  name           = var.name
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "network" {
-  name            = "${var.name}"
-  network_id      = "${openstack_networking_network_v2.network.id}"
-  cidr            = "${var.cidr}"
+  name            = var.name
+  network_id      = openstack_networking_network_v2.network.id
+  cidr            = var.cidr
   ip_version      = 4
   dns_nameservers = ["37.123.105.116", "37.123.105.117"]
 }
 
 resource "openstack_networking_router_v2" "network" {
-  name                = "${var.name}"
+  name                = var.name
   admin_state_up      = true
-  external_network_id = "${data.openstack_networking_network_v2.ext_net.id}"
+  external_network_id = data.openstack_networking_network_v2.ext_net.id
 }
 
 resource "openstack_networking_router_interface_v2" "network" {
-  router_id = "${openstack_networking_router_v2.network.id}"
-  subnet_id = "${openstack_networking_subnet_v2.network.id}"
+  router_id = openstack_networking_router_v2.network.id
+  subnet_id = openstack_networking_subnet_v2.network.id
 }
 
 resource "openstack_vpnaas_ike_policy_v2" "network" {
-  name = "${var.name}"
+  name = var.name
 }
 
 resource "openstack_vpnaas_ipsec_policy_v2" "network" {
-  name = "${var.name}"
+  name = var.name
 }
 
 resource "openstack_vpnaas_service_v2" "network" {
-  depends_on     = ["openstack_networking_router_interface_v2.network"]
-  name           = "${var.name}"
-  router_id      = "${openstack_networking_router_v2.network.id}"
+  depends_on     = [openstack_networking_router_interface_v2.network]
+  name           = var.name
+  router_id      = openstack_networking_router_v2.network.id
   admin_state_up = "true"
 }
 
 resource "openstack_vpnaas_endpoint_group_v2" "local" {
   name      = "${var.name} local"
   type      = "subnet"
-  endpoints = ["${openstack_networking_subnet_v2.network.id}"]
+  endpoints = [openstack_networking_subnet_v2.network.id]
   lifecycle {
     create_before_destroy = true
   }
 }
 
 output "vpnservice_id" {
-  value = "${openstack_vpnaas_service_v2.network.id}"
+  value = openstack_vpnaas_service_v2.network.id
 }
 
 output "ikepolicy_id" {
-  value = "${openstack_vpnaas_ike_policy_v2.network.id}"
+  value = openstack_vpnaas_ike_policy_v2.network.id
 }
 
 output "ipsecpolicy_id" {
-  value = "${openstack_vpnaas_ipsec_policy_v2.network.id}"
+  value = openstack_vpnaas_ipsec_policy_v2.network.id
 }
 
 output "peer_id" {
-  value = "${openstack_vpnaas_service_v2.network.external_v4_ip}"
+  value = openstack_vpnaas_service_v2.network.external_v4_ip
 }
 
 output "cidr" {
-  value = "${var.cidr}"
+  value = var.cidr
 }
 
 output "local_endpoint_group_id" {
-  value = "${openstack_vpnaas_endpoint_group_v2.local.id}"
+  value = openstack_vpnaas_endpoint_group_v2.local.id
 }

--- a/vpnaas/modules/network/vars.tf
+++ b/vpnaas/modules/network/vars.tf
@@ -1,12 +1,12 @@
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "name" {
-  type    = "string"
+  type    = string
   default = "unicorn"
 }
 
 variable "cidr" {
-  type = "string"
+  type = string
 }

--- a/vpnaas/modules/network/versions.tf
+++ b/vpnaas/modules/network/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/vpnaas/modules/simple-app/application.tf
+++ b/vpnaas/modules/simple-app/application.tf
@@ -1,5 +1,5 @@
 provider "openstack" {
-  region = "${var.region}"
+  region = var.region
 }
 
 data "openstack_networking_network_v2" "ext_net" {
@@ -7,19 +7,19 @@ data "openstack_networking_network_v2" "ext_net" {
 }
 
 resource "openstack_images_image_v2" "application" {
-  name             = "${var.name}"
+  name             = var.name
   image_source_url = "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
   container_format = "bare"
   disk_format      = "qcow2"
 }
 
 resource "openstack_compute_keypair_v2" "application" {
-  name       = "${var.name}"
-  public_key = "${var.public_key}"
+  name       = var.name
+  public_key = var.public_key
 }
 
 resource "openstack_compute_secgroup_v2" "application" {
-  name        = "${var.name}"
+  name        = var.name
   description = "Security Group for SSH access"
 
   rule {
@@ -38,32 +38,32 @@ resource "openstack_compute_secgroup_v2" "application" {
 }
 
 resource "openstack_compute_instance_v2" "application" {
-  name        = "${var.name}"
-  image_id    = "${openstack_images_image_v2.application.id}"
+  name        = var.name
+  image_id    = openstack_images_image_v2.application.id
   flavor_name = "m1.tiny"
-  key_pair    = "${openstack_compute_keypair_v2.application.name}"
+  key_pair    = openstack_compute_keypair_v2.application.name
 
   security_groups = [
     "default",
-    "${openstack_compute_secgroup_v2.application.name}",
+    openstack_compute_secgroup_v2.application.name,
   ]
 
   network {
-    name = "${var.network}"
+    name = var.network
   }
 
   lifecycle {
     ignore_changes = [
-      "image_id",
+      image_id,
     ]
   }
 }
 
 resource "openstack_compute_floatingip_v2" "application" {
-  pool = "${data.openstack_networking_network_v2.ext_net.name}"
+  pool = data.openstack_networking_network_v2.ext_net.name
 }
 
 resource "openstack_compute_floatingip_associate_v2" "application" {
-  floating_ip = "${openstack_compute_floatingip_v2.application.address}"
-  instance_id = "${openstack_compute_instance_v2.application.id}"
+  floating_ip = openstack_compute_floatingip_v2.application.address
+  instance_id = openstack_compute_instance_v2.application.id
 }

--- a/vpnaas/modules/simple-app/vars.tf
+++ b/vpnaas/modules/simple-app/vars.tf
@@ -1,17 +1,17 @@
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "name" {
-  type    = "string"
+  type    = string
   default = "unicorn"
 }
 
 variable "network" {
-  type    = "string"
+  type    = string
   default = "unicorn"
 }
 
 variable "public_key" {
-  type = "string"
+  type = string
 }

--- a/vpnaas/modules/simple-app/versions.tf
+++ b/vpnaas/modules/simple-app/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
     }
   }
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
If customers want to add and remove endpoints in the future, this is much easier to accomplish with endpoint groups.