### PR TITLE
DRAFT: Switch from openstack_compute_floatingip_associate_v2 to openstack_ne…

### DIFF
--- a/example-setup/modules/lb/main.tf
+++ b/example-setup/modules/lb/main.tf
@@ -114,7 +114,7 @@ resource "openstack_networking_floatingip_v2" "lb_floating_ips" {
   pool  = var.public_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "service_floating_ip_assocs" {
+resource "openstack_networking_floatingip_associate_v2" "service_floating_ip_assocs" {
   count       = var.num
   floating_ip = element(openstack_networking_floatingip_v2.lb_floating_ips.*.address, count.index)
   instance_id = element(openstack_compute_instance_v2.lb_instances.*.id, count.index)

--- a/example-setup/modules/servicehost/main.tf
+++ b/example-setup/modules/servicehost/main.tf
@@ -105,7 +105,7 @@ resource "openstack_networking_floatingip_v2" "service_floating_ips" {
   pool  = var.public_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "service_floating_ip_assocs" {
+resource "openstack_networking_floatingip_associate_v2" "service_floating_ip_assocs" {
   count       = var.num
   floating_ip = element(openstack_networking_floatingip_v2.service_floating_ips.*.address, count.index)
   instance_id = element(openstack_compute_instance_v2.service_instances.*.id, count.index)

--- a/lbaas-octavia-http/main.tf
+++ b/lbaas-octavia-http/main.tf
@@ -115,7 +115,7 @@ resource "openstack_networking_floatingip_v2" "fip_lbdemo_jumphost" {
   pool = "ext-net"
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_lbdemo" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_lbdemo" {
   floating_ip = openstack_networking_floatingip_v2.fip_lbdemo_jumphost.address
   instance_id = openstack_compute_instance_v2.instance_jumphost.id
 }

--- a/lbaas-octavia-https/main.tf
+++ b/lbaas-octavia-https/main.tf
@@ -115,7 +115,7 @@ resource "openstack_networking_floatingip_v2" "fip_lbdemo_jumphost" {
   pool = "ext-net"
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_lbdemo" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_lbdemo" {
   floating_ip = openstack_networking_floatingip_v2.fip_lbdemo_jumphost.address
   instance_id = openstack_compute_instance_v2.instance_jumphost.id
 }

--- a/lbaas/main.tf
+++ b/lbaas/main.tf
@@ -118,7 +118,7 @@ resource "openstack_networking_floatingip_v2" "fip_lbdemo_jumphost" {
   pool = "ext-net"
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_lbdemo" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_lbdemo" {
   floating_ip = openstack_networking_floatingip_v2.fip_lbdemo_jumphost.address
   instance_id = openstack_compute_instance_v2.instance_jumphost.id
 }

--- a/simple-instance-v6/instances-blue.tf
+++ b/simple-instance-v6/instances-blue.tf
@@ -18,7 +18,7 @@ resource "openstack_networking_floatingip_v2" "fip_blue" {
   pool = var.external_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_blue" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_blue" {
   floating_ip = openstack_networking_floatingip_v2.fip_blue.address
   instance_id = openstack_compute_instance_v2.instance_blue.id
 }

--- a/simple-instance-v6/instances-red.tf
+++ b/simple-instance-v6/instances-red.tf
@@ -18,7 +18,7 @@ resource "openstack_networking_floatingip_v2" "fip_red" {
   pool = var.external_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_red" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_red" {
   floating_ip = openstack_networking_floatingip_v2.fip_red.address
   instance_id = openstack_compute_instance_v2.instance_red.id
 }

--- a/simple-instance/instances-blue.tf
+++ b/simple-instance/instances-blue.tf
@@ -18,7 +18,7 @@ resource "openstack_networking_floatingip_v2" "fip_blue" {
   pool = var.external_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_blue" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_blue" {
   floating_ip = openstack_networking_floatingip_v2.fip_blue.address
   instance_id = openstack_compute_instance_v2.instance_blue.id
 }

--- a/simple-instance/instances-red.tf
+++ b/simple-instance/instances-red.tf
@@ -18,7 +18,7 @@ resource "openstack_networking_floatingip_v2" "fip_red" {
   pool = var.external_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "fipas_red" {
+resource "openstack_networking_floatingip_associate_v2" "fipas_red" {
   floating_ip = openstack_networking_floatingip_v2.fip_red.address
   instance_id = openstack_compute_instance_v2.instance_red.id
 }

--- a/vpnaas/modules/simple-app/application.tf
+++ b/vpnaas/modules/simple-app/application.tf
@@ -63,7 +63,7 @@ resource "openstack_networking_floatingip_v2" "application" {
   pool = data.openstack_networking_network_v2.ext_net.name
 }
 
-resource "openstack_compute_floatingip_associate_v2" "application" {
+resource "openstack_networking_floatingip_associate_v2" "application" {
   floating_ip = openstack_networking_floatingip_v2.application.address
   instance_id = openstack_compute_instance_v2.application.id
 }


### PR DESCRIPTION
…tworking_floatingip_associate_v2

openstack_compute_floatingip* is deprecated.

> Please note that managing floating IPs through the OpenStack Compute API has been deprecated.
> Unless you are using an older OpenStack environment, it is recommended to use the
> openstack_networking_floatingip_v2 resource instead, which uses the OpenStack Networking API.

https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_floatingip_v2